### PR TITLE
feat(discovery): endpoint discovery

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@
 - [x] Create statsd output
 - [x] Get the other prometheus annotations for endpoint configuration and move that into the input.
 - [x] (statsd) convert seperator to '.'
-- [ ] (discover,resource) Get service endpoints instead of service when clusterip is none or `/discover` is set to `endpoints`.
+- [x] (discover,resource) Get service endpoints instead of service when clusterip is none or `/discover` is set to `endpoints`.
 - [ ] (resource) Allow common tags from k8s information (namespace, pod, node, etc..).
 - [ ] (resource) Support field selectors for custom tags
 - [ ] (prometheus) Allow labels for tags

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -161,12 +161,8 @@ func (s *Scraper) initOutputs() ([]output.Output, error) {
 				s.log.Error(err, "unable to initialize logging output")
 				return nil, err
 			}
-		default:
-			s.log.Info("FOOOOOOOOOOOOOOOOOOOOO", "oo", oo)
 		}
 	}
-
-	s.log.Info("SSSSSSSSSSSSSSSSSSSSSS", "outputs", outputs)
 
 	return outputs, nil
 }


### PR DESCRIPTION
When a headless service is found, use endpoints for scraping. Introduces a new annotation to allow regular services to direct the scraper to discover endpoints.