### PR TITLE
feat(tags): allow labels as tags

### DIFF
--- a/config/crds/apex.ctx.sh_scrapers.yaml
+++ b/config/crds/apex.ctx.sh_scrapers.yaml
@@ -45,6 +45,8 @@ spec:
             type: object
           spec:
             properties:
+              allowLabels:
+                type: boolean
               annotationPrefix:
                 type: string
               authentication:

--- a/dev/examples/app.yaml
+++ b/dev/examples/app.yaml
@@ -20,6 +20,7 @@ metadata:
   namespace: example
   labels:
     app: app
+    group: example
 spec:
   replicas: 3
   selector:
@@ -29,8 +30,10 @@ spec:
     metadata:
       labels:
         app: app
+        group: example
       annotations:
         apex.ctx.sh/scrape: "true"
+        apex.ctx.sh/labels: group
     spec:
       containers:
       - name: app

--- a/dev/examples/scraper.yaml
+++ b/dev/examples/scraper.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       # k8s-app: kube-proxy
+  allowLabels: true
   annotationPrefix: apex.ctx.sh
   outputs:
     logger:

--- a/pkg/apis/apex.ctx.sh/v1/defaults.go
+++ b/pkg/apis/apex.ctx.sh/v1/defaults.go
@@ -25,6 +25,11 @@ func defaultedSpec(spec *ScraperSpec) {
 		spec.Resources = []string{"pods", "services"}
 	}
 
+	if spec.AllowLabels == nil {
+		spec.AllowLabels = new(bool)
+		*spec.AllowLabels = false
+	}
+
 	defaultedSpecOutput(spec.Outputs)
 }
 

--- a/pkg/apis/apex.ctx.sh/v1/defaults_test.go
+++ b/pkg/apis/apex.ctx.sh/v1/defaults_test.go
@@ -14,6 +14,7 @@ func TestDefaulted(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: ScraperSpec{
+			AllowLabels:           &[]bool{false}[0],
 			AnnotationPrefix:      &[]string{"prometheus.io"}[0],
 			ScrapeIntervalSeconds: &[]int32{10}[0],
 			Resources:             []string{"pods", "services"},

--- a/pkg/apis/apex.ctx.sh/v1/types.go
+++ b/pkg/apis/apex.ctx.sh/v1/types.go
@@ -72,6 +72,8 @@ type ScraperSpec struct {
 	// +optional
 	Workers *int32 `json:"workers,omitempty"`
 	// +optional
+	AllowLabels *bool `json:"allowLabels,omitempty"`
+	// +optional
 	ScrapeIntervalSeconds *int32 `json:"scrapeIntervalSeconds,omitempty"`
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
@@ -104,6 +106,8 @@ type ScraperSpec struct {
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=services/status,verbs=get
+// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=endpoints/status,verbs=get
 // +kubebuilder:rbac:groups=apex.ctx.sh,resources=scraper,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apex.ctx.sh,resources=scraper/status,verbs=get;update;patch
 type Scraper struct {

--- a/pkg/apis/apex.ctx.sh/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/apex.ctx.sh/v1/zz_generated.deepcopy.go
@@ -252,6 +252,11 @@ func (in *ScraperSpec) DeepCopyInto(out *ScraperSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AllowLabels != nil {
+		in, out := &in.AllowLabels, &out.AllowLabels
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ScrapeIntervalSeconds != nil {
 		in, out := &in.ScrapeIntervalSeconds, &out.ScrapeIntervalSeconds
 		*out = new(int32)

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -34,7 +34,9 @@ type Metric interface {
 	Name() string
 	// Tags returns the value of the metric
 	Tags() map[string]string
-	// AddLabel adds a label to the map
+	// AddTag adds a tag to the map
+	AddTag(string, string)
+	// Time returns the time the metric was collected
 	Time() time.Time
 	// Since returns the delta between the time the metric was
 	// collected and now.

--- a/pkg/metric/prometheus/prometheus.go
+++ b/pkg/metric/prometheus/prometheus.go
@@ -62,6 +62,10 @@ func (m *Metric) Tags() map[string]string {
 	return m.tags
 }
 
+func (m *Metric) AddTag(k, v string) {
+	m.tags[k] = v
+}
+
 func (m *Metric) Time() time.Time {
 	return m.time
 }

--- a/pkg/output/logger/logger.go
+++ b/pkg/output/logger/logger.go
@@ -18,7 +18,7 @@ func New(logger logr.Logger) (output.Output, error) {
 
 func (l *Logger) Send(m []metric.Metric) {
 	for _, x := range m {
-		l.log.Info("metric", "values", x.Values())
+		l.log.Info("metric", "metric_name", x.Name(), "metric_values", x.Values(), "metric_tags", x.Tags())
 	}
 }
 

--- a/pkg/scraper/resource.go
+++ b/pkg/scraper/resource.go
@@ -2,9 +2,11 @@ package scraper
 
 import (
 	"fmt"
+	"strings"
 
 	apexv1 "ctx.sh/apex-operator/pkg/apis/apex.ctx.sh/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Resource struct {
@@ -14,6 +16,8 @@ type Resource struct {
 	path      string
 	scheme    string
 	discovery string
+	labels    []string
+	tags      map[string]string
 }
 
 func (r *Resource) Enabled() bool {
@@ -24,25 +28,44 @@ func (r *Resource) URL() string {
 	return fmt.Sprintf("%s://%s:%s%s", r.scheme, r.ip, r.port, r.path)
 }
 
+func (r *Resource) Tags() map[string]string {
+	return r.tags
+}
+
+func (r *Resource) parseTags(obj metav1.ObjectMeta) {
+	r.tags = make(map[string]string)
+
+	labels := obj.GetLabels()
+	for _, name := range r.labels {
+		if v, ok := labels[name]; ok {
+			r.tags[name] = v
+		}
+	}
+}
+
 func FromService(svc corev1.Service, config apexv1.ScraperSpec) Resource {
 	// two options, hit service or hit endpoints... how to do that
 	resource := parseAnnotations(svc.GetAnnotations(), config)
+	resource.parseTags(svc.ObjectMeta)
 	resource.ip = svc.Spec.ClusterIP
 	return resource
 }
 
 func FromPod(pod corev1.Pod, config apexv1.ScraperSpec) Resource {
 	resource := parseAnnotations(pod.GetAnnotations(), config)
+	resource.parseTags(pod.ObjectMeta)
 	resource.ip = pod.Status.PodIP
 	return resource
 }
 
 func FromEndpointAddress(
 	address corev1.EndpointAddress,
+	obj metav1.ObjectMeta,
 	annotations map[string]string,
 	config apexv1.ScraperSpec,
 ) Resource {
 	resource := parseAnnotations(annotations, config)
+	resource.parseTags(obj)
 	resource.ip = address.IP
 	return resource
 }
@@ -55,12 +78,14 @@ func parseAnnotations(annotations map[string]string, config apexv1.ScraperSpec) 
 	var port string = "9090"
 	var path string = "/metrics"
 	var discovery string = "self"
+	var labels []string = []string{}
 
 	scrapeAnnotation := fmt.Sprintf("%s/scrape", prefix)
 	schemeAnnotation := fmt.Sprintf("%s/scheme", prefix)
 	portAnnotation := fmt.Sprintf("%s/port", prefix)
 	pathAnnotation := fmt.Sprintf("%s/path", prefix)
 	discoveryAnnotation := fmt.Sprintf("%s/discovery", prefix)
+	labelsAnnotations := fmt.Sprintf("%s/labels", prefix)
 
 	if a, ok := annotations[scrapeAnnotation]; ok {
 		enabled = a == "true"
@@ -82,11 +107,16 @@ func parseAnnotations(annotations map[string]string, config apexv1.ScraperSpec) 
 		discovery = a
 	}
 
+	if a, ok := annotations[labelsAnnotations]; ok {
+		labels = strings.Split(a, ",")
+	}
+
 	return Resource{
 		enabled:   enabled,
 		scheme:    scheme,
 		port:      port,
 		path:      path,
 		discovery: discovery,
+		labels:    labels,
 	}
 }

--- a/pkg/scraper/worker.go
+++ b/pkg/scraper/worker.go
@@ -90,7 +90,7 @@ func (w *Worker) scrape(r Resource) ([]metric.Metric, error) {
 		Client: w.httpClient,
 	}
 
-	m, err := input.Get()
+	m, err := input.Get(r.tags)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allows labels to be used as tags.  If `allowTags` has been enabled, pods and services can specify labels to be used as tags by adding the label names to scrape to a `<prefix>/labels` annotation.  If that annotation is not defined, no labels are collected.