### PR TITLE
feat(metrics): adding base metrics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@
 - [x] Status updates
 - [ ] Tag and metrics denylist
 - [ ] Tag and metrics allowlist
-- [ ] Metric
+- [x] Metrics
 - [ ] Event recorder
 - [ ] Add metrics
 - [ ] Container builds

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module ctx.sh/apex-operator
 go 1.18
 
 require (
-	ctx.sh/apex v0.1.0
+	ctx.sh/apex v0.2.0
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/felixge/httpsnoop v1.0.3
 	github.com/go-logr/logr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 ctx.sh/apex v0.1.0 h1:SdUic7b300YYtRsNBpooWsPQvJmDn/2j7yv9MtiJrdc=
 ctx.sh/apex v0.1.0/go.mod h1:jcNn1Pju+QRfQk/hWg9RuLGR5gg9OZw6zxBH4y10cKo=
+ctx.sh/apex v0.2.0 h1:dYyluz5FvajjVBEwAYaRj6gLcBEeOHOZsTx9ditwMII=
+ctx.sh/apex v0.2.0/go.mod h1:66hlCDMwTnzGgg2AloY1wdycB7qcoS4driaCWZZnSGw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 
+	"ctx.sh/apex"
 	apexv1 "ctx.sh/apex-operator/pkg/apis/apex.ctx.sh/v1"
 	"ctx.sh/apex-operator/pkg/controller"
 	"ctx.sh/apex-operator/pkg/scraper"
@@ -38,12 +39,31 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
+	metrics := apex.New(apex.MetricsOpts{
+		// make me configurable
+		Port:           9090,
+		ConstantLabels: []string{"controller", "apex.ctx.sh"},
+	})
+	// Need handle starts for apex-go a bit better, allow context
+	// and orchestrate shutdown better.
+	go func() {
+		err := metrics.Start()
+		if err != nil {
+			setupLog.Error(err, "unable to start prometheus")
+			os.Exit(1)
+		}
+	}()
+
 	ctrl.SetLogger(zap.New())
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:             scheme,
-		Port:               9443,
-		MetricsBindAddress: ":9090",
+		Scheme: scheme,
+		Port:   9443,
+		// I was hoping that controller-runtime would give access
+		// to the underlying registry or registerer to get any potential
+		// builtin metrics (don't know if there is any tbh), but there
+		// is no access, so take it over.
+		MetricsBindAddress: "0",
 		LeaderElection:     leaderElection,
 		LeaderElectionID:   "apex-operator-lock",
 	})
@@ -56,6 +76,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Log:      mgr.GetLogger().WithValues("controller", "apex"),
 		Scrapers: scraper.NewManager(),
+		Metrics:  metrics,
 	}
 
 	err = reconciler.SetupWithManager(mgr)

--- a/main.go
+++ b/main.go
@@ -40,9 +40,11 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 
 	metrics := apex.New(apex.MetricsOpts{
+		Separator: '_',
 		// make me configurable
 		Port:           9090,
 		ConstantLabels: []string{"controller", "apex.ctx.sh"},
+		PanicOnError:   true,
 	})
 	// Need handle starts for apex-go a bit better, allow context
 	// and orchestrate shutdown better.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -61,6 +61,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		request:  request,
 		ctx:      ctx,
 		log:      r.Log.WithValues("name", request.Name, "namespace", request.Namespace),
+		metrics:  r.Metrics,
 		recorder: r.Mgr.GetEventRecorderFor("ApexOperator"),
 		observed: NewObservedState(),
 		scrapers: r.Scrapers,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 
+	"ctx.sh/apex"
 	apexv1 "ctx.sh/apex-operator/pkg/apis/apex.ctx.sh/v1"
 	"ctx.sh/apex-operator/pkg/scraper"
 	"github.com/go-logr/logr"
@@ -42,6 +43,7 @@ type Reconciler struct {
 	Log      logr.Logger
 	Mgr      ctrl.Manager
 	Scrapers *scraper.Manager
+	Metrics  *apex.Metrics
 }
 
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
@@ -63,12 +65,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		observed: NewObservedState(),
 		scrapers: r.Scrapers,
 	}
+	r.Metrics.CounterInc("reconcile_total")
 	return handler.reconcile(request)
 }
 
 func (r *Reconciler) predicates() predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			r.Metrics.CounterInc("reconcile_update_total")
 			if e.ObjectOld == nil {
 				return false
 			}
@@ -79,9 +83,11 @@ func (r *Reconciler) predicates() predicate.Funcs {
 			return e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion()
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
+			r.Metrics.CounterInc("reconcile_create_total")
 			return true
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
+			r.Metrics.CounterInc("reconcile_delete_total")
 			return true
 		},
 	}
@@ -95,6 +101,7 @@ type Handler struct {
 	recorder record.EventRecorder
 	observed ObservedState
 	scrapers *scraper.Manager
+	metrics  *apex.Metrics
 }
 
 func (h *Handler) reconcile(request ctrl.Request) (ctrl.Result, error) {
@@ -118,6 +125,7 @@ func (h *Handler) reconcile(request ctrl.Request) (ctrl.Result, error) {
 		recorder: h.recorder,
 		observed: h.observed,
 		scrapers: h.scrapers,
+		metrics:  h.metrics,
 	}
 
 	return scraperReconciler.reconcile(h.ctx, request)

--- a/pkg/controller/scraper_reconciler.go
+++ b/pkg/controller/scraper_reconciler.go
@@ -45,6 +45,10 @@ var requeueResult reconcile.Result = ctrl.Result{
 
 func (r *ScraperReconciler) reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	metrics := r.metrics.WithPrefix("reconcile").WithLabels("name", "namespace")
+
+	timer := metrics.HistogramTimer("reconcile_seconds", request.Name, request.Namespace)
+	defer timer.ObserveDuration()
+
 	metrics.CounterInc("request_total", request.Name, request.Namespace)
 
 	if r.observed.scraper == nil {

--- a/pkg/controller/scraper_reconciler.go
+++ b/pkg/controller/scraper_reconciler.go
@@ -46,7 +46,7 @@ var requeueResult reconcile.Result = ctrl.Result{
 func (r *ScraperReconciler) reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	metrics := r.metrics.WithPrefix("reconcile").WithLabels("name", "namespace")
 
-	timer := metrics.HistogramTimer("reconcile_seconds", request.Name, request.Namespace)
+	timer := metrics.HistogramTimer("request_seconds", request.Name, request.Namespace)
 	defer timer.ObserveDuration()
 
 	metrics.CounterInc("request_total", request.Name, request.Namespace)

--- a/pkg/scraper/discovery.go
+++ b/pkg/scraper/discovery.go
@@ -152,7 +152,7 @@ func (d *Discovery) discoverPods(ctx context.Context, discovered *int, enabled *
 	}
 
 	*discovered += len(list.Items)
-	d.metrics.GaugeSet("pods_total", float64(*discovered), d.scraper.Name)
+	d.metrics.GaugeSet("pods", float64(*discovered), d.scraper.Name)
 	return nil
 }
 
@@ -184,7 +184,7 @@ func (d *Discovery) discoverServices(ctx context.Context, discovered *int, enabl
 	}
 
 	*discovered += len(list.Items)
-	d.metrics.GaugeSet("services_total", float64(*discovered), d.scraper.Name)
+	d.metrics.GaugeSet("services", float64(*discovered), d.scraper.Name)
 	return nil
 }
 
@@ -215,7 +215,7 @@ func (d *Discovery) discoverEndpoints(
 	}
 
 	*discovered += len(endpoints.Subsets)
-	d.metrics.GaugeSet("pods_total", float64(*discovered), d.scraper.Name)
+	d.metrics.GaugeSet("pods", float64(*discovered), d.scraper.Name)
 	return nil
 }
 

--- a/pkg/scraper/discovery.go
+++ b/pkg/scraper/discovery.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"ctx.sh/apex"
 	apexv1 "ctx.sh/apex-operator/pkg/apis/apex.ctx.sh/v1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -41,11 +42,13 @@ type DiscoveryOpts struct {
 	Scraper  apexv1.Scraper
 	Client   client.Client
 	Log      logr.Logger
+	Metrics  *apex.Metrics
 }
 
 type Discovery struct {
 	client    client.Client
 	log       logr.Logger
+	metrics   *apex.Metrics
 	scraper   apexv1.Scraper
 	workChan  chan<- Resource
 	startChan chan error
@@ -57,6 +60,7 @@ func NewDiscovery(opts DiscoveryOpts) *Discovery {
 	return &Discovery{
 		client:    opts.Client,
 		log:       opts.Log,
+		metrics:   opts.Metrics,
 		scraper:   opts.Scraper,
 		startChan: make(chan error),
 		stopChan:  make(chan struct{}),
@@ -102,6 +106,7 @@ func (d *Discovery) intervalRun(ctx context.Context) error {
 	var discovered int = 0
 	var enabled int = 0
 	d.log.Info("starting discovery run")
+	d.metrics.CounterInc("run_total", d.scraper.Name)
 	// These could be parallel
 	err := d.discoverPods(ctx, &discovered, &enabled)
 	if err != nil {
@@ -144,6 +149,7 @@ func (d *Discovery) discoverPods(ctx context.Context, discovered *int, enabled *
 	}
 
 	*discovered += len(list.Items)
+	d.metrics.GaugeSet("pods_total", float64(*discovered), d.scraper.Name)
 	return nil
 }
 
@@ -175,6 +181,7 @@ func (d *Discovery) discoverServices(ctx context.Context, discovered *int, enabl
 	}
 
 	*discovered += len(list.Items)
+	d.metrics.GaugeSet("services_total", float64(*discovered), d.scraper.Name)
 	return nil
 }
 
@@ -205,6 +212,7 @@ func (d *Discovery) discoverEndpoints(
 	}
 
 	*discovered += len(endpoints.Subsets)
+	d.metrics.GaugeSet("pods_total", float64(*discovered), d.scraper.Name)
 	return nil
 }
 

--- a/pkg/scraper/discovery.go
+++ b/pkg/scraper/discovery.go
@@ -103,6 +103,9 @@ func (d *Discovery) poll(ctx context.Context) {
 }
 
 func (d *Discovery) intervalRun(ctx context.Context) error {
+	timer := d.metrics.HistogramTimer("interval_seconds", d.scraper.Name)
+	defer timer.ObserveDuration()
+
 	var discovered int = 0
 	var enabled int = 0
 	d.log.Info("starting discovery run")

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -115,7 +115,7 @@ func (s *Scraper) up(ctx context.Context) {
 			workChan,
 			d.scraper.Spec,
 			s.log.WithValues("worker", i),
-			d.metrics.WithPrefix("output").WithLabels("name"),
+			s.metrics.WithPrefix("worker").WithLabels("name"),
 			outputs,
 		)
 		wg.Add(1)

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"sync"
 
+	"ctx.sh/apex"
 	apexv1 "ctx.sh/apex-operator/pkg/apis/apex.ctx.sh/v1"
 	"ctx.sh/apex-operator/pkg/output"
 	"ctx.sh/apex-operator/pkg/output/datadog"
@@ -38,6 +39,7 @@ type ScraperOpts struct {
 	Client  client.Client
 	Context context.Context
 	Log     logr.Logger
+	Metrics *apex.Metrics
 }
 
 type Scraper struct {
@@ -45,6 +47,7 @@ type Scraper struct {
 	client    client.Client
 	cancel    context.CancelFunc
 	log       logr.Logger
+	metrics   *apex.Metrics
 	scraper   apexv1.Scraper
 	startChan chan error
 	stopChan  chan struct{}
@@ -57,6 +60,7 @@ func NewScraper(opts ScraperOpts) *Scraper {
 		scraper:   opts.Scraper,
 		client:    opts.Client,
 		log:       opts.Log,
+		metrics:   opts.Metrics,
 		startChan: make(chan error),
 		stopChan:  make(chan struct{}),
 	}
@@ -88,6 +92,7 @@ func (s *Scraper) up(ctx context.Context) {
 		Client:   s.client,
 		Scraper:  s.scraper,
 		Log:      s.log.WithValues("name", "discovery"),
+		Metrics:  s.metrics.WithPrefix("discovery").WithLabels("name"),
 		WorkChan: workChan,
 	})
 	if err := <-d.Start(ctx); err != nil {
@@ -106,9 +111,11 @@ func (s *Scraper) up(ctx context.Context) {
 	for i := 0; i < int(workers); i++ {
 		s.log.Info("starting up worker", "id", i)
 		worker := NewWorker(
+			d.scraper.Name,
 			workChan,
 			d.scraper.Spec,
 			s.log.WithValues("worker", i),
+			d.metrics.WithPrefix("output").WithLabels("name"),
 			outputs,
 		)
 		wg.Add(1)


### PR DESCRIPTION
Adds base metrics to the service to capture reconcile, discovery and scrape stats.  I'll be revisiting the output interface to make it a little more friendly to gathering metrics and logging errors in the workers. I'll also need to come back and revisit the buckets for the timers.